### PR TITLE
Add script to increase the volume with a limit at 100%

### DIFF
--- a/i3/config
+++ b/i3/config
@@ -138,7 +138,7 @@ bindsym XF86MonBrightnessUp exec xbacklight -inc 5 # increase screen brightness
 bindsym XF86MonBrightnessDown exec xbacklight -dec 5 # decrease screen brightness
 
 # Volume controls
-bindsym XF86AudioRaiseVolume exec pactl set-sink-volume 0 +5%
+bindsym XF86AudioRaiseVolume exec --no-startup-id $HOME/.config/i3/increase_volume 5 #increase sound volume
 bindsym XF86AudioLowerVolume exec pactl set-sink-volume 0 -5%
 bindsym XF86AudioMute exec pactl set-sink-mute 0 toggle # amixer -q set Master toggle
 

--- a/i3/increase_volume
+++ b/i3/increase_volume
@@ -1,0 +1,7 @@
+#! /bin/sh
+
+CURRENT_VOL="$(pactl list sinks | grep '^[[:space:]]Volume:' | head -n $(( $SINK + 1 )) | tail -n 1 | sed -e 's,.* \([0-9][0-9]*\)%.*,\1,')"
+
+if [ "$CURRENT_VOL" -lt "100" ] ; then
+  pactl set-sink-volume 0 +${1}%
+fi


### PR DESCRIPTION
It could possibly be dangerous to increase the volume above 100%.

Use this script with a percentage as the first parameter.
It will only increase the volume if the current is below 100%.